### PR TITLE
Allow uploading empty files

### DIFF
--- a/client/app.py
+++ b/client/app.py
@@ -10,9 +10,15 @@ import lib.key_helper as kh
 
 
 def upload_file(file_path, url):
-    # Upload the file to the presigned URL
-    with open(file_path, "rb") as file:
-        response = requests.put(url, data=file)
+    
+
+    # Check if file has any content
+    if os.path.getsize(file_path) == 0:
+        response = requests.put(url)
+    else:
+        # Upload the file to the presigned URL
+        with open(file_path, "rb") as file:
+            response = requests.put(url, data=file)
     
     if response.status_code != 200:
         print(response.status_code, file=sys.stderr)

--- a/client/app.py
+++ b/client/app.py
@@ -10,8 +10,6 @@ import lib.key_helper as kh
 
 
 def upload_file(file_path, url):
-    
-
     # Check if file has any content
     if os.path.getsize(file_path) == 0:
         response = requests.put(url)
@@ -19,7 +17,7 @@ def upload_file(file_path, url):
         # Upload the file to the presigned URL
         with open(file_path, "rb") as file:
             response = requests.put(url, data=file)
-    
+
     if response.status_code != 200:
         print(response.status_code, file=sys.stderr)
         print(response.text, file=sys.stderr)
@@ -28,28 +26,24 @@ def upload_file(file_path, url):
     print("File uploaded successfully", file=sys.stderr)
     return True
 
-    
+
 def request_presigned_url(data, token, server_url):
-    headers = {
-        "Authorization": f"Bearer {token}"
-    }
+    headers = {"Authorization": f"Bearer {token}"}
 
     response = requests.post(server_url, headers=headers, json=data)
- 
+
     if response.status_code != 200:
         print(response.status_code, file=sys.stderr)
         print(response.text, file=sys.stderr)
         return
-    
 
-    presigned_url = response.json()['presigned_url']
-
+    presigned_url = response.json()["presigned_url"]
 
     return presigned_url
-    
+
 
 def main():
-    config_path = os.path.join(os.path.dirname(__file__), 'config.yaml')
+    config_path = os.path.join(os.path.dirname(__file__), "config.yaml")
     with open(config_path, "r") as file:
         config = yaml.safe_load(file)
 
@@ -74,9 +68,7 @@ def main():
     # Create body with file and user (server links user to public key)
     data = {"file": args.file, "user": config["user"]}
 
-    url = request_presigned_url(data, 
-                                token, 
-                                config['server_url'])
+    url = request_presigned_url(data, token, config["server_url"])
 
     if not url:
         sys.exit(1)
@@ -87,7 +79,6 @@ def main():
         sys.exit(1)
     else:
         sys.exit(0)
-
 
 
 if __name__ == "__main__":

--- a/client/config.yaml.example
+++ b/client/config.yaml.example
@@ -1,0 +1,5 @@
+private_key_path: keys/example_private.pem
+user: example
+email: example@example.com
+jwt_expiration: 3600
+server_url: https://server.com/api/endpoint

--- a/client/yaml.example
+++ b/client/yaml.example
@@ -1,5 +1,0 @@
-key_dir: ../keys
-contrib_id: test
-contrib_email: test@test.org
-exp: 3600
-server_url: https://server.com/api/endpoint


### PR DESCRIPTION
This change simply checks if the file is empty before making the put request. The `data` argument can be left out when there is no data to send.

I also added the `config.yaml.example` for the client which was missing.

Let me know if you have any questions!